### PR TITLE
Dont convert buffers

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ fab.listen = function( write, port ) {
               headers = undefined;
             }
             
-            res.write( body.toString() );
+            res.write( body );
           }
         }
   


### PR DESCRIPTION
We discussed this the other day.  This seems like a better solution.  Though, you can use something like this to sniff out a buffer:

```
if !(body instanceof Buffer)
  body = body.toString()
res.write(body)
```
