### PR TITLE
Fix to make it work with node v0.6.6

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,8 +23,7 @@ function imports( exports ) {
     
     else {
       console.log( name.replace( /\W/g, "/" ), name.replace( /\W/g, "/" ) )
-    
-      require( name.replace( /\W/g, "/" ) )( function( lib ) {
+      require( './' + name.replace( /\W/g, "/" ) )( function( lib ) {
         libs.push( lib );
         loop();
       }, imports );


### PR DESCRIPTION
This is an small fix to make it work fab on `v0.6.6` previously this was the error that `fab` was throwing up when I ran the `demo.js` after that everything works fine. 

```
 Error: Cannot find module 'run'
    at Function._resolveFilename (module.js:334:11)
    at Function._load (module.js:279:25)
    at Module.require (module.js:357:17)
    at require (module.js:368:17)
    at loop (/dev/fab/index.js:26:7)
    at imports (/dev/fab/index.js:31:4)
    at /dev/fab/demo.js:18:10
    at fab (/dev/fab/index.js:3:22)
    at repl:1:15
    at REPLServer.eval (repl.js:80:21)
```
